### PR TITLE
Port LuckPermsGUI to LuckPerms5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>\${java.version}</source>
-                    <target>\${java.version}</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -82,13 +82,13 @@
         <dependency>
             <groupId>net.luckperms</groupId>
             <artifactId>api</artifactId>
-            <version>5.1</version>
+            <version>5.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.14.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/Main.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/Main.java
@@ -14,7 +14,6 @@ import me.AsVaidas.LuckPemsGUI.util.Metrics;
 import me.AsVaidas.LuckPemsGUI.util.updatechecker.JoinEvents;
 import me.AsVaidas.LuckPemsGUI.util.updatechecker.UpdateChecker;
 import me.AsVaidas.LuckPemsGUI.util.Logger;
-import me.AsVaidas.LuckPemsGUI.util.MetricsLite;
 import me.AsVaidas.LuckPemsGUI.util.Settings;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.InvalidConfigurationException;

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/Tools.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/Tools.java
@@ -75,10 +75,11 @@ public class Tools {
 			Bukkit.dispatchCommand(p, command);
 		});
 	}
-	
+
+	// Not usable doesn't send the correct context's anymore
 	public static String contextConverter(ContextSet contextSet) {
 		StringBuilder eilute = new StringBuilder();
-		for (Entry<String, String> entry : contextSet.toMultimap().entries()) {
+		for (Entry<String, String> entry : contextSet.toFlattenedMap().entrySet()) {
 			if (eilute.length() != 0)
 				eilute.append(" ");
 			eilute.append(entry.getKey()).append("=").append(entry.getValue());

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/groups/EditGroup.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/groups/EditGroup.java
@@ -45,7 +45,7 @@ public class EditGroup implements Listener {
 		setWeight.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), g);
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 	
@@ -59,7 +59,7 @@ public class EditGroup implements Listener {
 		setName.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), g);
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 	
@@ -73,7 +73,7 @@ public class EditGroup implements Listener {
 		rename.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), g);
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 	
@@ -87,7 +87,7 @@ public class EditGroup implements Listener {
 		clone.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), l.getGroupManager().getGroup(message));
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 	
@@ -106,9 +106,9 @@ public class EditGroup implements Listener {
 							"&cWeight: &e"+weight,
 							"&cCounts:",
 							"   &cNodes: &e"+group.getNodes().size(),
-							"   &cPermissions: &e"+group.getPermissions().size(),
-							"   &cPrefixes: &e"+group.getCachedData().getMetaData(Contexts.global()).getPrefixes().size(),
-							"   &cSuffixes: &e"+group.getCachedData().getMetaData(Contexts.global()).getSuffixes().size()),
+							"   &cPermissions: &e"+group.getDistinctNodes().size(),
+							"   &cPrefixes: &e"+group.getCachedData().getMetaData().getPrefixes().size(),
+							"   &cSuffixes: &e"+group.getCachedData().getMetaData().getSuffixes().size()),
 					1);
 			myInventory.setItem(4, info);
 			// ----------------------- INFO ------------------------------
@@ -368,7 +368,7 @@ public class EditGroup implements Listener {
 							Tools.sendCommand(p, "lp deletegroup "+g.getName());
 							Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> {
 								GroupsGUI.open(p);
-							}, 3);
+							}, 5);
 						}
 					}
 			}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Parents.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Parents.java
@@ -9,19 +9,13 @@ package me.AsVaidas.LuckPemsGUI.groups;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
-import net.luckperms.api.context.ContextSet;
 import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.group.Group;
 import net.luckperms.api.node.Node;
 import net.luckperms.api.node.NodeType;
-import net.luckperms.api.node.metadata.NodeMetadataKey;
-import net.luckperms.api.node.types.ChatMetaNode;
-import net.luckperms.api.node.types.PermissionNode;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -97,8 +91,8 @@ public class Parents implements Listener {
 		
 		int from = 45*page-1;
 		int to = 45*(page+1)-1;
-		for (Node permission : group.getNodes()) {
-			if (permission.getType() == NodeType.META) continue;
+		for (Node permission : group.getDistinctNodes()) {
+			if (permission.getType() != NodeType.META) continue;
 			if (from <= sk && sk < to) {
 
 
@@ -159,8 +153,8 @@ public class Parents implements Listener {
 							int id = Integer.parseInt(ChatColor.stripColor(item.getItemMeta().getLore().get(0).split(" ")[1]));
 
 							int sk = 0;
-							for (Node permission : g.getNodes()) {
-								if (permission.getType() == NodeType.META) continue;
+							for (Node permission : g.getDistinctNodes()) {
+								if (permission.getType() != NodeType.META) continue;
 
 								String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
 								String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
@@ -182,7 +176,7 @@ public class Parents implements Listener {
 							int page = current;
 							Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> {
 								open(p, g, page);
-							}, 3);
+							}, 5);
 						}
 					}
 			}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Permissions.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Permissions.java
@@ -9,11 +9,15 @@ package me.AsVaidas.LuckPemsGUI.groups;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.group.Group;
 import net.luckperms.api.node.Node;
+import net.luckperms.api.node.NodeType;
+import net.luckperms.api.node.types.PermissionNode;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -92,9 +96,9 @@ public class Permissions implements Listener {
 						"&cWeight: &e"+weight,
 						"&cCounts:",
 						"  &cNodes: &e"+group.getNodes().size(),
-						"  &cPermissions: &e"+group.getPermissions().size(),
-						"  &cPrefixes: &e"+group.getCachedData().getMetaData(Contexts.global()).getPrefixes().size(),
-						"  &cSuffixes: &e"+group.getCachedData().getMetaData(Contexts.global()).getSuffixes().size()),
+						"  &cPermissions: &e"+group.getDistinctNodes().size(),
+						"  &cPrefixes: &e"+group.getCachedData().getMetaData().getPrefixes().size(),
+						"  &cSuffixes: &e"+group.getCachedData().getMetaData().getSuffixes().size()),
 				1);
 		myInventory.setItem(4, info);
 		// ----------------------- INFO ------------------------------
@@ -104,18 +108,18 @@ public class Permissions implements Listener {
 		
 		int from = 45*page-1;
 		int to = 45*(page+1)-1;
-		for (Node permission : group.getPermissions()) {
-			if (permission.isGroupNode()) continue;
-			if (permission.isPrefix()) continue;
-			if (permission.isSuffix()) continue;
-			if (permission.isMeta()) continue;
-			if (permission.getPermission().contains("weight")) continue;
+		for (Node permission : group.getNodes()) {
+			if (permission.getType() == NodeType.META) continue;
+			if (permission.getType() == NodeType.PREFIX) continue;
+			if (permission.getType() == NodeType.SUFFIX) continue;
+			if (permission.getType() == NodeType.CHAT_META) continue;
+			if (permission.getType() == NodeType.WEIGHT) continue;
 			if (from <= sk && sk < to) {
-				String expiration = permission.isTemporary() ? Tools.getTime(permission.getExpiry().getTime()) : "Never";
-				String server = permission.getServer().orElse("global");
-				String world = permission.getWorld().orElse("global");
+				String expiration = permission.hasExpiry() ? Tools.getTime(permission.getExpiry().toEpochMilli()) : "Never";
+				String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+				String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
 				ItemStack item = Tools.button(Material.TNT,
-						"&6"+permission.getPermission(),
+						"&6"+permission.getKey(),
 						Arrays.asList(
 								"&cID: &e"+sk,
 								"&cExpires in: &e"+expiration,
@@ -168,26 +172,22 @@ public class Permissions implements Listener {
 							int id = Integer.parseInt(ChatColor.stripColor(item.getItemMeta().getLore().get(0).split(" ")[1]));
 
 							int sk = 0;
-							for (Node permission : g.getPermissions()) {
-								if (permission.isGroupNode()) continue;
-								if (permission.isPrefix()) continue;
-								if (permission.isSuffix()) continue;
-								if (permission.isMeta()) continue;
-								if (permission.getPermission().contains("weight")) continue;
+							for (Node permission : g.getNodes()) {
+								if (permission.getType() == NodeType.META) continue;
+								if (permission.getType() == NodeType.PREFIX) continue;
+								if (permission.getType() == NodeType.SUFFIX) continue;
+								if (permission.getType() == NodeType.CHAT_META) continue;
+								if (permission.getType() == NodeType.WEIGHT) continue;
 								if (sk == id) {
-									if (Main.plugin.getConfig().getBoolean("UseLuckPerms5.Enabled")) {
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp group " + g.getName() + " permission unsettemp " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp group " + g.getName() + " permission unset " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										break;
-									} else {
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp group "+g.getName()+" unsettemp "+'"'+permission.getPermission()+'"'+" "+Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp group "+g.getName()+" unset "+'"'+permission.getPermission()+'"'+" "+Tools.contextConverter(permission.getFullContexts()));
-										break;
-									}
+
+									String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+									String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
+
+									if (permission.hasExpiry())
+										Tools.sendCommand(p, "lp group " + g.getName() + " permission unsettemp " + '"' + permission.getKey() + '"' + " " + server + " " + world);
+									else
+										Tools.sendCommand(p, "lp group " + g.getName() + " permission unset " + '"' + permission.getKey() + '"' + " " + server + " " + world);
+									break;
 								}
 								sk++;
 							}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Permissions.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Permissions.java
@@ -9,7 +9,6 @@ package me.AsVaidas.LuckPemsGUI.groups;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
@@ -17,7 +16,6 @@ import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.group.Group;
 import net.luckperms.api.node.Node;
 import net.luckperms.api.node.NodeType;
-import net.luckperms.api.node.types.PermissionNode;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -108,7 +106,7 @@ public class Permissions implements Listener {
 		
 		int from = 45*page-1;
 		int to = 45*(page+1)-1;
-		for (Node permission : group.getNodes()) {
+		for (Node permission : group.getDistinctNodes()) {
 			if (permission.getType() == NodeType.META) continue;
 			if (permission.getType() == NodeType.PREFIX) continue;
 			if (permission.getType() == NodeType.SUFFIX) continue;
@@ -172,7 +170,7 @@ public class Permissions implements Listener {
 							int id = Integer.parseInt(ChatColor.stripColor(item.getItemMeta().getLore().get(0).split(" ")[1]));
 
 							int sk = 0;
-							for (Node permission : g.getNodes()) {
+							for (Node permission : g.getDistinctNodes()) {
 								if (permission.getType() == NodeType.META) continue;
 								if (permission.getType() == NodeType.PREFIX) continue;
 								if (permission.getType() == NodeType.SUFFIX) continue;
@@ -199,7 +197,7 @@ public class Permissions implements Listener {
 							int page = current;
 							Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> {
 								open(p, g, page);
-							}, 3);
+							}, 5);
 						}
 					}
 			}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Prefix.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Prefix.java
@@ -9,11 +9,15 @@ package me.AsVaidas.LuckPemsGUI.groups;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.group.Group;
 import net.luckperms.api.node.Node;
+import net.luckperms.api.node.NodeType;
+import net.luckperms.api.node.types.PermissionNode;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -77,9 +81,9 @@ public class Prefix implements Listener {
 						"&cWeight: &e"+weight,
 						"&cCounts:",
 						"  &cNodes: &e"+group.getNodes().size(),
-						"  &cPermissions: &e"+group.getPermissions().size(),
-						"  &cPrefixes: &e"+group.getCachedData().getMetaData(Contexts.global()).getPrefixes().size(),
-						"  &cSuffixes: &e"+group.getCachedData().getMetaData(Contexts.global()).getSuffixes().size()),
+						"  &cPermissions: &e"+group.getDistinctNodes().size(),
+						"  &cPrefixes: &e"+group.getCachedData().getMetaData().getPrefixes().size(),
+						"  &cSuffixes: &e"+group.getCachedData().getMetaData().getSuffixes().size()),
 				1);
 		myInventory.setItem(4, info);
 		// ----------------------- INFO ------------------------------
@@ -89,17 +93,17 @@ public class Prefix implements Listener {
 		
 		int from = 45*page-1;
 		int to = 45*(page+1)-1;
-		for (Node permission : group.getPermissions()) {
-			if (!permission.isPrefix()) continue;
+		for (Node permission : group.getNodes()) {
+			if (permission.getType() == NodeType.PREFIX) continue;
 			if (from <= sk && sk < to) {
-				String expiration = permission.isTemporary() ? Tools.getTime(permission.getExpiry().getTime()) : "Never";
-				String server = permission.getServer().orElse("global");
-				String world = permission.getWorld().orElse("global");
+				String expiration = permission.hasExpiry() ? Tools.getTime(permission.getExpiry().toEpochMilli()) : "Never";
+				String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+				String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
 				ItemStack item = Tools.button(Material.TNT,
-						"&6"+permission.getPrefix().getValue(),
+						"&6"+permission.getKey(),
 						Arrays.asList(
 								"&cID: &e"+sk,
-								"&cPosition: &e"+permission.getPrefix().getKey(),
+								"&cPosition: &e"+permission.getKey(),
 								"&cExpires in: &e"+expiration,
 								"&cValue: &e"+permission.getValue(),
 								"&cServer: &e"+server,
@@ -150,23 +154,19 @@ public class Prefix implements Listener {
 							int id = Integer.parseInt(ChatColor.stripColor(item.getItemMeta().getLore().get(0).split(" ")[1]));
 
 							int sk = 0;
-							for (Node permission : g.getPermissions()) {
-								if (!permission.isPrefix()) continue;
+							for (Node permission : g.getNodes()) {
+								if (permission.getType() != NodeType.PREFIX) continue;
 								if (sk == id) {
-									if (Main.plugin.getConfig().getBoolean("UseLuckPerms5.Enabled")) {
-										Map.Entry<Integer, String> prefix = permission.getPrefix();
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp group " + g.getName() + " meta removetempprefix " + prefix.getKey() + " " + '"' + prefix.getValue() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp group " + g.getName() + " meta removeprefix " + prefix.getKey() + " " + '"' + prefix.getValue() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										break;
-									} else {
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp group " + g.getName() + " unsettemp " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp group " + g.getName() + " unset " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										break;
-									}
+									Map.Entry<Integer, String> prefix = permission.getPrefix(); // Doesn't exist in API v5
+
+									String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+									String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
+
+									if (permission.hasExpiry())
+										Tools.sendCommand(p, "lp group " + g.getName() + " meta removetempprefix " + prefix.getValue() + " " + '"' + prefix.getKey() + '"' + " " + server + " " + world);
+									else
+										Tools.sendCommand(p, "lp group " + g.getName() + " meta removeprefix " + prefix.getValue() + " " + '"' + prefix.getKey() + '"' + " " + server + " " + world);
+									break;
 								}
 								sk++;
 							}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Suffix.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Suffix.java
@@ -9,11 +9,15 @@ package me.AsVaidas.LuckPemsGUI.groups;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.group.Group;
 import net.luckperms.api.node.Node;
+import net.luckperms.api.node.NodeType;
+import net.luckperms.api.node.types.PermissionNode;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -78,9 +82,9 @@ public class Suffix implements Listener {
 						"&cWeight: &e"+weight,
 						"&cCounts:",
 						"  &cNodes: &e"+group.getNodes().size(),
-						"  &cPermissions: &e"+group.getPermissions().size(),
-						"  &cPrefixes: &e"+group.getCachedData().getMetaData(Contexts.global()).getPrefixes().size(),
-						"  &cSuffixes: &e"+group.getCachedData().getMetaData(Contexts.global()).getSuffixes().size()),
+						"  &cPermissions: &e"+group.getDistinctNodes().size(),
+						"  &cPrefixes: &e"+group.getCachedData().getMetaData().getPrefixes().size(),
+						"  &cSuffixes: &e"+group.getCachedData().getMetaData().getSuffixes().size()),
 				1);
 		myInventory.setItem(4, info);
 		// ----------------------- INFO ------------------------------
@@ -90,17 +94,17 @@ public class Suffix implements Listener {
 		
 		int from = 45*page-1;
 		int to = 45*(page+1)-1;
-		for (Node permission : group.getPermissions()) {
-			if (!permission.isSuffix()) continue;
+		for (Node permission : group.getNodes()) {
+			if (permission.getType() != NodeType.SUFFIX) continue;
 			if (from <= sk && sk < to) {
-				String expiration = permission.isTemporary() ? Tools.getTime(permission.getExpiry().getTime()) : "Never";
-				String server = permission.getServer().orElse("global");
-				String world = permission.getWorld().orElse("global");
+				String expiration = permission.hasExpiry() ? Tools.getTime(permission.getExpiry().toEpochMilli()) : "Never";
+				String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+				String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
 				ItemStack item = Tools.button(Material.TNT,
-						"&6"+permission.getSuffix().getValue(),
+						"&6"+permission.getKey(),
 						Arrays.asList(
 								"&cID: &e"+sk,
-								"&cPosition: &e"+permission.getSuffix().getKey(),
+								"&cPosition: &e"+permission.getKey(),
 								"&cExpires in: &e"+expiration,
 								"&cValue: &e"+permission.getValue(),
 								"&cServer: &e"+server,
@@ -151,23 +155,19 @@ public class Suffix implements Listener {
 							int id = Integer.parseInt(ChatColor.stripColor(item.getItemMeta().getLore().get(0).split(" ")[1]));
 
 							int sk = 0;
-							for (Node permission : g.getPermissions()) {
-								if (!permission.isSuffix()) continue;
+							for (Node permission : g.getNodes()) {
+								if (permission.getType() == NodeType.SUFFIX) continue;
 								if (sk == id) {
-									if (Main.plugin.getConfig().getBoolean("UseLuckPerms5.Enabled")) {
-										Map.Entry<Integer, String> suffix = permission.getSuffix();
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp group " + g.getName() + " meta removetempsuffix " + suffix.getKey() + " " + '"' + suffix.getValue() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp group " + g.getName() + " meta removesuffix " + suffix.getKey() + " " + '"' + suffix.getValue() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										break;
-									} else {
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp group " + g.getName() + " unsettemp " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp group " + g.getName() + " unset " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										break;
-									}
+									Map.Entry<Integer, String> suffix = permission.getSuffix(); // Doesn't exist in API v5
+
+									String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+									String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
+
+									if (permission.hasExpiry())
+										Tools.sendCommand(p, "lp group " + g.getName() + " meta removetempsuffix " + suffix.getValue() + " " + '"' + suffix.getKey() + '"' + " " + server + " " + world);
+									else
+										Tools.sendCommand(p, "lp group " + g.getName() + " meta removesuffix " + suffix.getValue() + " " + '"' + suffix.getKey() + '"' + " " + server + " " + world);
+									break;
 								}
 								sk++;
 							}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Suffix.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/groups/Suffix.java
@@ -9,7 +9,6 @@ package me.AsVaidas.LuckPemsGUI.groups;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
@@ -17,7 +16,7 @@ import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.group.Group;
 import net.luckperms.api.node.Node;
 import net.luckperms.api.node.NodeType;
-import net.luckperms.api.node.types.PermissionNode;
+import net.luckperms.api.node.types.SuffixNode;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -94,17 +93,18 @@ public class Suffix implements Listener {
 		
 		int from = 45*page-1;
 		int to = 45*(page+1)-1;
-		for (Node permission : group.getNodes()) {
+		for (Node permission : group.getDistinctNodes()) {
 			if (permission.getType() != NodeType.SUFFIX) continue;
 			if (from <= sk && sk < to) {
+				SuffixNode suffix = ((SuffixNode) permission);
 				String expiration = permission.hasExpiry() ? Tools.getTime(permission.getExpiry().toEpochMilli()) : "Never";
 				String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
 				String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
 				ItemStack item = Tools.button(Material.TNT,
-						"&6"+permission.getKey(),
+						"&6"+suffix.getMetaValue(),
 						Arrays.asList(
 								"&cID: &e"+sk,
-								"&cPosition: &e"+permission.getKey(),
+								"&cPosition: &e"+suffix.getPriority(),
 								"&cExpires in: &e"+expiration,
 								"&cValue: &e"+permission.getValue(),
 								"&cServer: &e"+server,
@@ -155,18 +155,18 @@ public class Suffix implements Listener {
 							int id = Integer.parseInt(ChatColor.stripColor(item.getItemMeta().getLore().get(0).split(" ")[1]));
 
 							int sk = 0;
-							for (Node permission : g.getNodes()) {
-								if (permission.getType() == NodeType.SUFFIX) continue;
+							for (Node permission : g.getDistinctNodes()) {
+								if (permission.getType() != NodeType.SUFFIX) continue;
 								if (sk == id) {
-									Map.Entry<Integer, String> suffix = permission.getSuffix(); // Doesn't exist in API v5
+									SuffixNode suffix = ((SuffixNode) permission);
 
 									String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
 									String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
 
 									if (permission.hasExpiry())
-										Tools.sendCommand(p, "lp group " + g.getName() + " meta removetempsuffix " + suffix.getValue() + " " + '"' + suffix.getKey() + '"' + " " + server + " " + world);
+										Tools.sendCommand(p, "lp group " + g.getName() + " meta removetempsuffix " + suffix.getPriority() + " " + '"' + suffix.getMetaValue() + '"' + " " + server + " " + world);
 									else
-										Tools.sendCommand(p, "lp group " + g.getName() + " meta removesuffix " + suffix.getValue() + " " + '"' + suffix.getKey() + '"' + " " + server + " " + world);
+										Tools.sendCommand(p, "lp group " + g.getName() + " meta removesuffix " + suffix.getPriority() + " " + '"' + suffix.getMetaValue() + '"' + " " + server + " " + world);
 									break;
 								}
 								sk++;
@@ -179,7 +179,7 @@ public class Suffix implements Listener {
 							int page = current;
 							Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> {
 								open(p, g, page);
-							}, 3);
+							}, 5);
 						}
 					}
 			}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/tracks/EditTrack.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/tracks/EditTrack.java
@@ -44,7 +44,7 @@ public class EditTrack implements Listener {
 		addgroup.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), g);
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 	
@@ -58,7 +58,7 @@ public class EditTrack implements Listener {
 		insertgroup.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), g);
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 	
@@ -72,7 +72,7 @@ public class EditTrack implements Listener {
 		rename.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), g);
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 	

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/tracks/EditTrack.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/tracks/EditTrack.java
@@ -86,7 +86,7 @@ public class EditTrack implements Listener {
 		clone.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), g);
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 
@@ -98,7 +98,7 @@ public class EditTrack implements Listener {
 					"&6Info",
 					Arrays.asList(
 							"&cName: &e"+group.getName(),
-							"&cAll groups: &e"+group.getSize()),
+							"&cAll groups: &e"+group.getGroups().size()),
 					1);
 			myInventory.setItem(4, info);
 			// ----------------------- INFO ------------------------------
@@ -175,7 +175,7 @@ public class EditTrack implements Listener {
 							Tools.sendCommand(p, "lp deletetrack "+g.getName());
 							Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> {
 								TracksGUI.open(p);
-							}, 3);
+							}, 5);
 						} else if (name.equals("Rename")) {
 							Tools.sendMessage(p, "&eWrite in chat:");
 							Tools.sendMessage(p, "&8<&7Name&8>");
@@ -192,7 +192,7 @@ public class EditTrack implements Listener {
 							Tools.sendCommand(p, "lp track "+g.getName()+" remove "+ChatColor.stripColor(item.getItemMeta().getDisplayName()));
 							Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> {
 								open(p, g);
-							}, 3);
+							}, 5);
 						}
 					}
 			}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/users/EditUser.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/users/EditUser.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ExecutionException;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.context.ContextManager;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.track.Track;
 import org.bukkit.Bukkit;
@@ -44,11 +45,11 @@ public class EditUser implements Listener {
 		String message = e.getMessage();
 		User g = primarygroup.get(e.getPlayer());
 		
-		Tools.sendCommand(e.getPlayer(), "lp user "+g.getName()+" parent set "+message);
+		Tools.sendCommand(e.getPlayer(), "lp user "+g.getUsername()+" parent set "+message);
 		primarygroup.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), g);
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 
@@ -58,12 +59,12 @@ public class EditUser implements Listener {
 		String message = e.getMessage();
 		User g = clone.get(e.getPlayer());
 		
-		Tools.sendCommand(e.getPlayer(), "lp user "+g.getName()+" clone "+message);
+		Tools.sendCommand(e.getPlayer(), "lp user "+g.getUsername()+" clone "+message);
 		clone.remove(e.getPlayer());
 		
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), l.getUserManager().getUser(message));
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 
@@ -73,12 +74,12 @@ public class EditUser implements Listener {
 		String message = e.getMessage();
 		User g = promote.get(e.getPlayer());
 		
-		Tools.sendCommand(e.getPlayer(), "lp user "+g.getName()+" promote "+message);
+		Tools.sendCommand(e.getPlayer(), "lp user "+g.getUsername()+" promote "+message);
 		promote.remove(e.getPlayer());
 		
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), g);
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 
@@ -89,12 +90,12 @@ public class EditUser implements Listener {
 		String message = e.getMessage();
 		User g = demote.get(e.getPlayer());
 		
-		Tools.sendCommand(e.getPlayer(), "lp user "+g.getName()+" demote "+message);
+		Tools.sendCommand(e.getPlayer(), "lp user "+g.getUsername()+" demote "+message);
 		demote.remove(e.getPlayer());
 		
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			open(e.getPlayer(), g);
-		}, 3);
+		}, 5);
 		e.setCancelled(true);
 	}
 
@@ -105,17 +106,17 @@ public class EditUser implements Listener {
 			ItemStack info = Tools.button(Material.ARMOR_STAND,
 					"&6Info",
 					Arrays.asList(
-							"&cName: &e"+user.getName(),
-							"&cUUID: &e"+user.getUuid(),
+							"&cName: &e"+user.getUsername(),
+							"&cUUID: &e"+user.getUniqueId(),
 							"&cGroup: &e"+user.getPrimaryGroup(),
 							"&cCounts:",
 							"&c   Nodes: &e"+user.getNodes().size(),
-							"&c   Permissions: &e"+user.getPermissions().size(),
-							"&c   Prefixes: &e"+user.getCachedData().getMetaData(Contexts.global()).getPrefixes().size(),
-							"&c   Suffixes: &e"+user.getCachedData().getMetaData(Contexts.global()).getSuffixes().size(),
+							"&c   Permissions: &e"+user.getDistinctNodes().size(),
+							"&c   Prefixes: &e"+user.getCachedData().getMetaData().getPrefixes().size(),
+							"&c   Suffixes: &e"+user.getCachedData().getMetaData().getSuffixes().size(),
 							"&cCached data:",
-							"&c   Current prefix: &e"+user.getCachedData().getMetaData(Contexts.global()).getPrefix(),
-							"&c   Current suffix: &e"+user.getCachedData().getMetaData(Contexts.global()).getSuffix()
+							"&c   Current prefix: &e"+user.getCachedData().getMetaData().getPrefix(),
+							"&c   Current suffix: &e"+user.getCachedData().getMetaData().getSuffix()
 							),
 					1);
 			myInventory.setItem(4, info);
@@ -213,10 +214,9 @@ public class EditUser implements Listener {
 		});
 		p.openInventory(myInventory);
 	}
-	
 
 	public static void openTracks(Player p, User user, String type) {
-		Inventory myInventory = Bukkit.createInventory(null, 54, ChatColor.AQUA + "Select " + type + " " + user.getName()); //+type+" "+user.getName()+" track");
+		Inventory myInventory = Bukkit.createInventory(null, 54, ChatColor.AQUA + "Select " + type + " " + user.getUsername()); //+type+" "+user.getName()+" track");
 		Tools.onAsync(() -> {
 			ItemStack back = Tools.button(Material.BARRIER, "&6Back", Arrays.asList(""), 1);
 			myInventory.setItem(8, back);
@@ -227,7 +227,7 @@ public class EditUser implements Listener {
 				ItemStack item = Tools.button(Material.TNT,
 						"&6"+track.getName(),
 						Arrays.asList(
-								"&cGroups: &e"+track.getSize()
+								"&cGroups: &e"+track.getGroups().size()
 								), 1);
 				myInventory.setItem(i, item);
 				
@@ -255,9 +255,9 @@ public class EditUser implements Listener {
 					} else {
 							String type = e.getView().getTitle().split(" ")[1];
 							if (type.equalsIgnoreCase("promote")) {
-								Tools.sendCommand(p, "lp user "+g.getName()+" promote "+name);
+								Tools.sendCommand(p, "lp user "+g.getUsername()+" promote "+name);
 							} else if (type.equalsIgnoreCase("demote")) {
-								Tools.sendCommand(p, "lp user "+g.getName()+" demote "+name);
+								Tools.sendCommand(p, "lp user "+g.getUsername()+" demote "+name);
 							}
 						}
 					}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/users/EditUser.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/users/EditUser.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
-import net.luckperms.api.context.ContextManager;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.track.Track;
 import org.bukkit.Bukkit;

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/users/Parents.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/users/Parents.java
@@ -9,11 +9,15 @@ package me.AsVaidas.LuckPemsGUI.users;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.Node;
+import net.luckperms.api.node.NodeType;
+import net.luckperms.api.node.types.PermissionNode;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -38,7 +42,7 @@ public class Parents implements Listener {
 		String message = e.getMessage();
 		User g = addParent.get(e.getPlayer());
 		
-		Tools.sendCommand(e.getPlayer(), "lp user "+g.getName()+" parent add "+message);
+		Tools.sendCommand(e.getPlayer(), "lp user "+g.getUsername()+" parent add "+message);
 		addParent.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
@@ -52,7 +56,7 @@ public class Parents implements Listener {
 		String message = e.getMessage();
 		User g = addTempParent.get(e.getPlayer());
 
-		Tools.sendCommand(e.getPlayer(), "lp user "+g.getName()+" parent addtemp "+message);
+		Tools.sendCommand(e.getPlayer(), "lp user "+g.getUsername()+" parent addtemp "+message);
 		addTempParent.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
@@ -64,24 +68,24 @@ public class Parents implements Listener {
 
 	public static void open(Player p, User user, int page) {
 		Inventory myInventory = Bukkit.createInventory(null, 54, ChatColor.AQUA+"LuckPerms user parents");
-		//Tools.onAsync(() -> {
+		Tools.onAsync(() -> {
 
 		
 		// ----------------------- INFO ------------------------------
 		ItemStack info = Tools.button(Material.ARMOR_STAND,
 				"&6Info",
 				Arrays.asList(
-						"&cName: &e"+user.getName(),
-						"&cUUID: &e"+user.getUuid(),
+						"&cName: &e"+user.getUsername(),
+						"&cUUID: &e"+user.getUniqueId(),
 						"&cGroup: &e"+user.getPrimaryGroup(),
 						"&cCounts:",
 						"&c   Nodes: &e"+user.getNodes().size(),
-						"&c   Permissions: &e"+user.getPermissions().size(),
-						"&c   Prefixes: &e"+user.getCachedData().getMetaData(Contexts.global()).getPrefixes().size(),
-						"&c   Suffixes: &e"+user.getCachedData().getMetaData(Contexts.global()).getSuffixes().size(),
+						"&c   Permissions: &e"+user.getDistinctNodes().size(),
+						"&c   Prefixes: &e"+user.getCachedData().getMetaData().getPrefixes().size(),
+						"&c   Suffixes: &e"+user.getCachedData().getMetaData().getSuffixes().size(),
 						"&cCached data:",
-						"&c   Current prefix: &e"+user.getCachedData().getMetaData(Contexts.global()).getPrefix(),
-						"&c   Current suffix: &e"+user.getCachedData().getMetaData(Contexts.global()).getSuffix()
+						"&c   Current prefix: &e"+user.getCachedData().getMetaData().getPrefix(),
+						"&c   Current suffix: &e"+user.getCachedData().getMetaData().getSuffix()
 						),
 				1);
 		myInventory.setItem(4, info);
@@ -92,14 +96,14 @@ public class Parents implements Listener {
 		
 		int from = 45*page-1;
 		int to = 45*(page+1)-1;
-		for (Node permission : user.getPermissions()) {
-			if (!permission.isGroupNode()) continue;
+		for (Node permission : user.getNodes()) {
+			if (permission.getType() == NodeType.META) continue;
 			if (from <= sk && sk < to) {
-				String expiration = permission.isTemporary() ? Tools.getTime(permission.getExpiry().getTime()) : "Never";
-				String server = permission.getServer().orElse("global");
-				String world = permission.getWorld().orElse("global");
+				String expiration = permission.hasExpiry() ? Tools.getTime(permission.getExpiry().toEpochMilli()) : "Never";
+				String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+				String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
 				ItemStack item = Tools.button(Material.TNT,
-						"&6"+permission.getGroupName(),
+						"&6"+permission.getKey(),
 						Arrays.asList(
 								"&cID: &e"+sk,
 								"&cExpires in: &e"+expiration,
@@ -122,7 +126,7 @@ public class Parents implements Listener {
 		ItemStack back = Tools.button(Material.BARRIER, "&6Back", Arrays.asList(""), 1);
 		myInventory.setItem(8, back);
 		
-		//});
+		});
 		p.openInventory(myInventory);
 	}
 
@@ -152,22 +156,18 @@ public class Parents implements Listener {
 							int id = Integer.parseInt(ChatColor.stripColor(item.getItemMeta().getLore().get(0).split(" ")[1]));
 
 							int sk = 0;
-							for (Node permission : g.getPermissions()) {
-								if (!permission.isGroupNode()) continue;
+							for (Node permission : g.getNodes()) {
+								if (permission.getType() == NodeType.META) continue;
+
+								String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+								String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
+
 								if (sk == id) {
-									if (Main.plugin.getConfig().getBoolean("UseLuckPerms5.Enabled")) {
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp user " + g.getName() + " parent removetemp " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp user " + g.getName() + " parent remove " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										break;
-									} else {
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp user " + g.getName() + " unsettemp " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp user " + g.getName() + " unset " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										break;
-									}
+									if (permission.hasExpiry())
+										Tools.sendCommand(p, "lp user " + g.getUsername() + " parent removetemp " + '"' + permission.getKey() + '"' + " " + server + " " + world);
+									else
+										Tools.sendCommand(p, "lp user " + g.getUsername() + " parent remove " + '"' + permission.getKey() + '"' + " " + server + " " + world);
+									break;
 								}
 								sk++;
 							}
@@ -179,7 +179,7 @@ public class Parents implements Listener {
 							int page = current;
 							Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> {
 								open(p, g, page);
-							}, 3);
+							}, 5);
 						}
 					}
 			}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/users/Parents.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/users/Parents.java
@@ -9,7 +9,6 @@ package me.AsVaidas.LuckPemsGUI.users;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
@@ -17,7 +16,6 @@ import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.Node;
 import net.luckperms.api.node.NodeType;
-import net.luckperms.api.node.types.PermissionNode;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -46,7 +44,7 @@ public class Parents implements Listener {
 		addParent.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
-		});
+		}, 5);
 		e.setCancelled(true);
 	}
 	
@@ -60,7 +58,7 @@ public class Parents implements Listener {
 		addTempParent.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
-		});
+		}, 5);
 		e.setCancelled(true);
 	}
 
@@ -96,8 +94,8 @@ public class Parents implements Listener {
 		
 		int from = 45*page-1;
 		int to = 45*(page+1)-1;
-		for (Node permission : user.getNodes()) {
-			if (permission.getType() == NodeType.META) continue;
+		for (Node permission : user.getDistinctNodes()) {
+			if (permission.getType() != NodeType.META) continue;
 			if (from <= sk && sk < to) {
 				String expiration = permission.hasExpiry() ? Tools.getTime(permission.getExpiry().toEpochMilli()) : "Never";
 				String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
@@ -156,8 +154,8 @@ public class Parents implements Listener {
 							int id = Integer.parseInt(ChatColor.stripColor(item.getItemMeta().getLore().get(0).split(" ")[1]));
 
 							int sk = 0;
-							for (Node permission : g.getNodes()) {
-								if (permission.getType() == NodeType.META) continue;
+							for (Node permission : g.getDistinctNodes()) {
+								if (permission.getType() != NodeType.META) continue;
 
 								String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
 								String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/users/Permissions.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/users/Permissions.java
@@ -9,7 +9,6 @@ package me.AsVaidas.LuckPemsGUI.users;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
@@ -17,7 +16,6 @@ import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.Node;
 import net.luckperms.api.node.NodeType;
-import net.luckperms.api.node.types.PermissionNode;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -47,7 +45,7 @@ public class Permissions implements Listener {
 		addPermission.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
-		});
+		}, 5);
 		e.setCancelled(true);
 	}
 	
@@ -61,7 +59,7 @@ public class Permissions implements Listener {
 		addTempPermission.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
-		});
+		}, 5);
 		e.setCancelled(true);
 	}
 	
@@ -75,7 +73,7 @@ public class Permissions implements Listener {
 		checkIfHas.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
-		});
+		}, 5);
 		e.setCancelled(true);
 	}
 
@@ -110,7 +108,7 @@ public class Permissions implements Listener {
 		
 		int from = 45*page-1;
 		int to = 45*(page+1)-1;
-		for (Node permission : user.getNodes()) {
+		for (Node permission : user.getDistinctNodes()) {
 			if (permission.getType() == NodeType.META) continue;
 			if (permission.getType() == NodeType.PREFIX) continue;
 			if (permission.getType() == NodeType.SUFFIX) continue;
@@ -174,7 +172,7 @@ public class Permissions implements Listener {
 							int id = Integer.parseInt(ChatColor.stripColor(item.getItemMeta().getLore().get(0).split(" ")[1]));
 
 							int sk = 0;
-							for (Node permission : g.getNodes()) {
+							for (Node permission : g.getDistinctNodes()) {
 								if (permission.getType() == NodeType.META) continue;
 								if (permission.getType() == NodeType.PREFIX) continue;
 								if (permission.getType() == NodeType.SUFFIX) continue;

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/users/Prefix.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/users/Prefix.java
@@ -6,23 +6,15 @@
 
 package me.AsVaidas.LuckPemsGUI.users;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
-import net.luckperms.api.cacheddata.CachedMetaData;
-import net.luckperms.api.context.ContextManager;
 import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.Node;
 import net.luckperms.api.node.NodeType;
-import net.luckperms.api.node.types.PermissionNode;
 import net.luckperms.api.node.types.PrefixNode;
-import net.luckperms.api.query.QueryMode;
-import net.luckperms.api.query.QueryOptions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -51,7 +43,7 @@ public class Prefix implements Listener {
 		addPrefix.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
-		});
+		}, 5);
 		e.setCancelled(true);
 	}
 	
@@ -65,7 +57,7 @@ public class Prefix implements Listener {
 		addTempPrefix.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
-		});
+		}, 5);
 		e.setCancelled(true);
 	}
 
@@ -104,14 +96,15 @@ public class Prefix implements Listener {
 		for (Node permission : user.getDistinctNodes()) {
 			if (permission.getType() != NodeType.PREFIX) continue;
 			if (from <= sk && sk < to) {
+				PrefixNode prefix = ((PrefixNode) permission);
 				String expiration = permission.hasExpiry() ? Tools.getTime(permission.getExpiry().toEpochMilli()) : "Never";
 				String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
 				String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
 				ItemStack item = Tools.button(Material.TNT,
-						"&6"+permission.getKey(),
+						"&6"+prefix.getMetaValue(),
 						Arrays.asList(
 								"&cID: &e"+sk,
-								"&cPosition: &e"+permission.getKey(),
+								"&cPosition: &e"+prefix.getPriority(),
 								"&cExpires in: &e"+expiration,
 								"&cValue: &e"+permission.getValue(),
 								"&cServer: &e"+server,
@@ -163,17 +156,17 @@ public class Prefix implements Listener {
 
 							int sk = 0;
 							for (Node permission : g.getDistinctNodes()) {
-								if (permission.getType() == NodeType.PREFIX) continue;
+								if (permission.getType() != NodeType.PREFIX) continue;
 								if (sk == id) {
-									Map.Entry<Integer, String> prefix = permission.getPrefix(); // Doesn't exist in API v5
+									PrefixNode prefix = ((PrefixNode) permission);
 
 									String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
 									String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
 
 									if (permission.hasExpiry())
-										Tools.sendCommand(p, "lp user " + g.getUsername() + " meta removetempprefix " + prefix.getValue() + " " + '"' + prefix.getKey() + '"' + " " + server + " " + world);
+										Tools.sendCommand(p, "lp user " + g.getUsername() + " meta removetempprefix " + prefix.getPriority() + " " + '"' + prefix.getMetaValue() + '"' + " " + server + " " + world);
 									else
-										Tools.sendCommand(p, "lp user " + g.getUsername() + " meta removeprefix " + prefix.getValue() + " " + '"' + prefix.getKey() + '"' + " " + server + " " + world);
+										Tools.sendCommand(p, "lp user " + g.getUsername() + " meta removeprefix " + prefix.getPriority() + " " + '"' + prefix.getMetaValue() + '"' + " " + server + " " + world);
 									break;
 								}
 								sk++;

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/users/Prefix.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/users/Prefix.java
@@ -9,11 +9,20 @@ package me.AsVaidas.LuckPemsGUI.users;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.cacheddata.CachedMetaData;
+import net.luckperms.api.context.ContextManager;
+import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.Node;
+import net.luckperms.api.node.NodeType;
+import net.luckperms.api.node.types.PermissionNode;
+import net.luckperms.api.node.types.PrefixNode;
+import net.luckperms.api.query.QueryMode;
+import net.luckperms.api.query.QueryOptions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -38,7 +47,7 @@ public class Prefix implements Listener {
 		String message = e.getMessage();
 		User g = addPrefix.get(e.getPlayer());
 		
-		Tools.sendCommand(e.getPlayer(), "lp user "+g.getName()+" meta addprefix "+message);
+		Tools.sendCommand(e.getPlayer(), "lp user "+g.getUsername()+" meta addprefix "+message);
 		addPrefix.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
@@ -52,7 +61,7 @@ public class Prefix implements Listener {
 		String message = e.getMessage();
 		User g = addTempPrefix.get(e.getPlayer());
 
-		Tools.sendCommand(e.getPlayer(), "lp user "+g.getName()+" meta addtempprefix "+message);
+		Tools.sendCommand(e.getPlayer(), "lp user "+g.getUsername()+" meta addtempprefix "+message);
 		addTempPrefix.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
@@ -71,17 +80,17 @@ public class Prefix implements Listener {
 		ItemStack info = Tools.button(Material.ARMOR_STAND,
 				"&6Info",
 				Arrays.asList(
-						"&cName: &e"+user.getName(),
-						"&cUUID: &e"+user.getUuid(),
+						"&cName: &e"+user.getUsername(),
+						"&cUUID: &e"+user.getUniqueId(),
 						"&cGroup: &e"+user.getPrimaryGroup(),
 						"&cCounts:",
 						"&c   Nodes: &e"+user.getNodes().size(),
-						"&c   Permissions: &e"+user.getPermissions().size(),
-						"&c   Prefixes: &e"+user.getCachedData().getMetaData(Contexts.global()).getPrefixes().size(),
-						"&c   Suffixes: &e"+user.getCachedData().getMetaData(Contexts.global()).getSuffixes().size(),
+						"&c   Permissions: &e"+user.getDistinctNodes().size(),
+						"&c   Prefixes: &e"+user.getCachedData().getMetaData().getPrefixes().size(),
+						"&c   Suffixes: &e"+user.getCachedData().getMetaData().getSuffixes().size(),
 						"&cCached data:",
-						"&c   Current prefix: &e"+user.getCachedData().getMetaData(Contexts.global()).getPrefix(),
-						"&c   Current suffix: &e"+user.getCachedData().getMetaData(Contexts.global()).getSuffix()
+						"&c   Current prefix: &e"+user.getCachedData().getMetaData().getPrefix(),
+						"&c   Current suffix: &e"+user.getCachedData().getMetaData().getSuffix()
 						),
 				1);
 		myInventory.setItem(4, info);
@@ -92,17 +101,17 @@ public class Prefix implements Listener {
 		
 		int from = 45*page-1;
 		int to = 45*(page+1)-1;
-		for (Node permission : user.getPermissions()) {
-			if (!permission.isPrefix()) continue;
+		for (Node permission : user.getDistinctNodes()) {
+			if (permission.getType() != NodeType.PREFIX) continue;
 			if (from <= sk && sk < to) {
-				String expiration = permission.isTemporary() ? Tools.getTime(permission.getExpiry().getTime()) : "Never";
-				String server = permission.getServer().orElse("global");
-				String world = permission.getWorld().orElse("global");
+				String expiration = permission.hasExpiry() ? Tools.getTime(permission.getExpiry().toEpochMilli()) : "Never";
+				String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+				String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
 				ItemStack item = Tools.button(Material.TNT,
-						"&6"+permission.getPrefix().getValue(),
+						"&6"+permission.getKey(),
 						Arrays.asList(
 								"&cID: &e"+sk,
-								"&cPosition: &e"+permission.getPrefix().getKey(),
+								"&cPosition: &e"+permission.getKey(),
 								"&cExpires in: &e"+expiration,
 								"&cValue: &e"+permission.getValue(),
 								"&cServer: &e"+server,
@@ -153,23 +162,19 @@ public class Prefix implements Listener {
 							int id = Integer.parseInt(ChatColor.stripColor(item.getItemMeta().getLore().get(0).split(" ")[1]));
 
 							int sk = 0;
-							for (Node permission : g.getPermissions()) {
-								if (!permission.isPrefix()) continue;
+							for (Node permission : g.getDistinctNodes()) {
+								if (permission.getType() == NodeType.PREFIX) continue;
 								if (sk == id) {
-									if (Main.plugin.getConfig().getBoolean("UseLuckPerms5.Enabled")) {
-										Map.Entry<Integer, String> prefix = permission.getPrefix();
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp user " + g.getName() + " meta removetempprefix " + prefix.getKey() + " " + '"' + prefix.getValue() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp user " + g.getName() + " meta removeprefix " + prefix.getKey() + " " + '"' + prefix.getValue() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										break;
-									} else {
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp user " + g.getName() + " unsettemp " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp user " + g.getName() + " unset " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										break;
-									}
+									Map.Entry<Integer, String> prefix = permission.getPrefix(); // Doesn't exist in API v5
+
+									String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+									String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
+
+									if (permission.hasExpiry())
+										Tools.sendCommand(p, "lp user " + g.getUsername() + " meta removetempprefix " + prefix.getValue() + " " + '"' + prefix.getKey() + '"' + " " + server + " " + world);
+									else
+										Tools.sendCommand(p, "lp user " + g.getUsername() + " meta removeprefix " + prefix.getValue() + " " + '"' + prefix.getKey() + '"' + " " + server + " " + world);
+									break;
 								}
 								sk++;
 							}
@@ -181,7 +186,7 @@ public class Prefix implements Listener {
 							int page = current;
 							Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> {
 								open(p, g, page);
-							}, 3);
+							}, 5);
 						}
 					}
 			}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/users/Suffix.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/users/Suffix.java
@@ -9,11 +9,15 @@ package me.AsVaidas.LuckPemsGUI.users;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.Node;
+import net.luckperms.api.node.NodeType;
+import net.luckperms.api.node.types.PermissionNode;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -38,7 +42,7 @@ public class Suffix implements Listener {
 		String message = e.getMessage();
 		User g = addPrefix.get(e.getPlayer());
 		
-		Tools.sendCommand(e.getPlayer(), "lp user "+g.getName()+" meta addsuffix "+message);
+		Tools.sendCommand(e.getPlayer(), "lp user "+g.getUsername()+" meta addsuffix "+message);
 		addPrefix.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
@@ -52,7 +56,7 @@ public class Suffix implements Listener {
 		String message = e.getMessage();
 		User g = addTempPrefix.get(e.getPlayer());
 
-		Tools.sendCommand(e.getPlayer(), "lp user "+g.getName()+" meta addtempsuffix "+message);
+		Tools.sendCommand(e.getPlayer(), "lp user "+g.getUsername()+" meta addtempsuffix "+message);
 		addTempPrefix.remove(e.getPlayer());
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), g);
@@ -71,17 +75,17 @@ public class Suffix implements Listener {
 		ItemStack info = Tools.button(Material.ARMOR_STAND,
 				"&6Info",
 				Arrays.asList(
-						"&cName: &e"+user.getName(),
-						"&cUUID: &e"+user.getUuid(),
+						"&cName: &e"+user.getUsername(),
+						"&cUUID: &e"+user.getUniqueId(),
 						"&cGroup: &e"+user.getPrimaryGroup(),
 						"&cCounts:",
 						"&c   Nodes: &e"+user.getNodes().size(),
-						"&c   Permissions: &e"+user.getPermissions().size(),
-						"&c   Prefixes: &e"+user.getCachedData().getMetaData(Contexts.global()).getPrefixes().size(),
-						"&c   Suffixes: &e"+user.getCachedData().getMetaData(Contexts.global()).getSuffixes().size(),
+						"&c   Permissions: &e"+user.getDistinctNodes().size(),
+						"&c   Prefixes: &e"+user.getCachedData().getMetaData().getPrefixes().size(),
+						"&c   Suffixes: &e"+user.getCachedData().getMetaData().getSuffixes().size(),
 						"&cCached data:",
-						"&c   Current prefix: &e"+user.getCachedData().getMetaData(Contexts.global()).getPrefix(),
-						"&c   Current suffix: &e"+user.getCachedData().getMetaData(Contexts.global()).getSuffix()
+						"&c   Current prefix: &e"+user.getCachedData().getMetaData().getPrefix(),
+						"&c   Current suffix: &e"+user.getCachedData().getMetaData().getSuffix()
 						),
 				1);
 		myInventory.setItem(4, info);
@@ -92,17 +96,17 @@ public class Suffix implements Listener {
 		
 		int from = 45*page-1;
 		int to = 45*(page+1)-1;
-		for (Node permission : user.getPermissions()) {
-			if (!permission.isSuffix()) continue;
+		for (Node permission : user.getNodes()) {
+			if (permission.getType() != NodeType.SUFFIX) continue;
 			if (from <= sk && sk < to) {
-				String expiration = permission.isTemporary() ? Tools.getTime(permission.getExpiry().getTime()) : "Never";
-				String server = permission.getServer().orElse("global");
-				String world = permission.getWorld().orElse("global");
+				String expiration = permission.hasExpiry() ? Tools.getTime(permission.getExpiry().toEpochMilli()) : "Never";
+				String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+				String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
 				ItemStack item = Tools.button(Material.TNT,
-						"&6"+permission.getSuffix().getValue(),
+						"&6"+permission.getKey(),
 						Arrays.asList(
 								"&cID: &e"+sk,
-								"&cPosition: &e"+permission.getSuffix().getKey(),
+								"&cPosition: &e"+permission.getKey(),
 								"&cExpires in: &e"+expiration,
 								"&cValue: &e"+permission.getValue(),
 								"&cServer: &e"+server,
@@ -153,23 +157,19 @@ public class Suffix implements Listener {
 							int id = Integer.parseInt(ChatColor.stripColor(item.getItemMeta().getLore().get(0).split(" ")[1]));
 
 							int sk = 0;
-							for (Node permission : g.getPermissions()) {
-								if (!permission.isSuffix()) continue;
+							for (Node permission : g.getNodes()) {
+								if (permission.getType() == NodeType.SUFFIX) continue;
 								if (sk == id) {
-									if (Main.plugin.getConfig().getBoolean("UseLuckPerms5.Enabled")) {
-										Map.Entry<Integer, String> suffix = permission.getSuffix();
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp user " + g.getName() + " meta removetempsuffix " + suffix.getKey() + " " + '"' + suffix.getValue() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp user " + g.getName() + " meta removesuffix " + suffix.getKey() + " " + '"' + suffix.getValue() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										break;
-									} else {
-										if (permission.isTemporary())
-											Tools.sendCommand(p, "lp user " + g.getName() + " unsettemp " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										else
-											Tools.sendCommand(p, "lp user " + g.getName() + " unset " + '"' + permission.getPermission() + '"' + " " + Tools.contextConverter(permission.getFullContexts()));
-										break;
-									}
+									Map.Entry<Integer, String> suffix = permission.getSuffix(); // Doesn't exist in API v5
+
+									String server = permission.getContexts().getAnyValue(DefaultContextKeys.SERVER_KEY).orElse("global");
+									String world = permission.getContexts().getAnyValue(DefaultContextKeys.WORLD_KEY).orElse("global");
+
+									if (permission.hasExpiry())
+										Tools.sendCommand(p, "lp user " + g.getUsername() + " meta removetempsuffix " + suffix.getValue() + " " + '"' + suffix.getKey() + '"' + " " + server + " " + world);
+									else
+										Tools.sendCommand(p, "lp user " + g.getUsername() + " meta removesuffix " + suffix.getValue() + " " + '"' + suffix.getKey() + '"' + " " + server + " " + world);
+									break;
 								}
 								sk++;
 							}
@@ -181,7 +181,7 @@ public class Suffix implements Listener {
 							int page = current;
 							Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> {
 								open(p, g, page);
-							}, 3);
+							}, 5);
 						}
 					}
 			}

--- a/src/main/java/me/AsVaidas/LuckPemsGUI/users/UsersGUI.java
+++ b/src/main/java/me/AsVaidas/LuckPemsGUI/users/UsersGUI.java
@@ -39,7 +39,7 @@ public class UsersGUI implements Listener {
 
 		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.getInstance(), () -> {
 			EditUser.open(e.getPlayer(), message);
-		});
+		}, 5);
 			
 		e.setCancelled(true);
 	}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,8 +25,3 @@ SilentStart:
 #Permissions:
 #luckperms.gui - Use the GUI
 #=======================================================
-#Please turn this setting to true if you are using LuckPerms 5+!
-#This will change some of the commands to work with the new version of LuckPerms.
-UseLuckPerms5:
-  Enabled: false
-


### PR DESCRIPTION
This has been tested on 1.8-1.17

Changes:
- Native LuckPerms 5 support has been added
- LuckPerms 4 support has been removed
- Removed unused imports
- Updated LuckPerms API to 5.3
- Updated log4j to 2.14.1